### PR TITLE
fix: search command number by factory user logged in

### DIFF
--- a/src/modules/order/order.service.ts
+++ b/src/modules/order/order.service.ts
@@ -28,10 +28,19 @@ export class OrderService {
 			.select(/* SQL */ `DISTINCT TOP 5 manu.mo_no`, 'mo_no')
 			.addSelect(/* SQL */ `manu.created`, 'created')
 			.from(/* SQL */ `wuerp_vnrd.dbo.ta_manufacturmst`, 'manu')
-			.where(/* SQL */ `manu.cofactory_code = :factoryCode`, { factoryCode })
-			.andWhere(/* SQL */ `manu.mo_no LIKE :searchTerm`, { searchTerm: `%${searchTerm}%` })
+			.where(/* SQL */ `manu.cofactory_code = :factoryCode`)
+			.andWhere(/* SQL */ `manu.mo_no LIKE :searchTerm`)
 			.andWhere(/* SQL */ `manu.created >= CAST(DATEADD(YEAR, -2, GETDATE()) AS DATE)`)
-			.orderBy(/* SQL */ `manu.created`, 'DESC')
+			.andWhere(
+				/* SQL */ `(
+				(:factoryCode = 'VA1' AND RIGHT(LEFT(manu.mo_no, 3), 1) = 'A') OR
+				(:factoryCode = 'VB1' AND RIGHT(LEFT(manu.mo_no, 3), 1) = 'B') OR
+				(:factoryCode = 'VB2' AND RIGHT(LEFT(manu.mo_no, 3), 1) = 'C') OR
+				(:factoryCode = 'CA1' AND RIGHT(LEFT(manu.mo_no, 3), 1) = 'D')
+		  		)`
+			)
+			.setParameters({ factoryCode, searchTerm: `%${searchTerm}%` })
+			.orderBy('manu.created', 'DESC')
 			.getRawMany()
 	}
 

--- a/src/modules/rfid/services/rfid-inbound.service.ts
+++ b/src/modules/rfid/services/rfid-inbound.service.ts
@@ -313,19 +313,36 @@ export class RFIDInboundService {
 	}
 
 	public async searchExchangableOrder(params: SearchCustOrderParamsDTO) {
-		return await this.dataSourceERP.query(
-			/* SQL */ `
-            SELECT a.mo_no FROM wuerp_vnrd.dbo.ta_manufacturmst a
-            LEFT JOIN wuerp_vnrd.dbo.ta_productmst b ON b.mat_code = a.mat_code AND b.isactive = 'Y'
-            LEFT JOIN wuerp_vnrd.dbo.ta_shoefactorymst c ON c.shoestyle_systemcodefty = b.shoestyle_systemcodefty AND c.isactive = 'Y'
-            WHERE 
-               a.created >= CAST(DATEADD(YEAR, -2, GETDATE()) AS DATE)
-               AND a.mo_no LIKE CONCAT('%', @0, '%')
-               AND a.cofactory_code = @1
-               AND b.mat_ecolor = @2
-            ORDER BY a.created DESC
-            `,
-			[params.q, params['factory_code.eq'], params['mat_ecolor.eq']]
-		)
+		return await this.dataSourceERP
+			.createQueryBuilder()
+			.select(/* SQL */ `DISTINCT TOP 5 a.mo_no`)
+			.addSelect(/* SQL */ `a.created`, 'created')
+			.from('ta_manufacturmst', 'a')
+			.leftJoin('ta_productmst', 'b', /* SQL */ `b.mat_code = a.mat_code AND b.isactive = 'Y'`)
+			.leftJoin(
+				'ta_shoefactorymst',
+				'c',
+				/* SQL */ `c.shoestyle_systemcodefty = b.shoestyle_systemcodefty AND c.isactive = 'Y'`
+			)
+			.where(/* SQL */ `a.created >= CAST(DATEADD(YEAR, -2, GETDATE()) AS DATE)`)
+			.andWhere(/* SQL */ `a.mo_no LIKE CONCAT('%',:search, '%')`)
+			.andWhere(/* SQL */ `a.cofactory_code = :factoryCode`)
+			.andWhere(/* SQL */ `b.mat_ecolor = :color`)
+			.andWhere(
+				/* SQL */ `(
+					(:factoryCode = 'VA1' AND RIGHT(LEFT(a.mo_no, 3), 1) = 'A') OR
+					(:factoryCode = 'VB1' AND RIGHT(LEFT(a.mo_no, 3), 1) = 'B') OR
+					(:factoryCode = 'VB2' AND RIGHT(LEFT(a.mo_no, 3), 1) = 'C') OR
+					(:factoryCode = 'CA1' AND RIGHT(LEFT(a.mo_no, 3), 1) = 'D')
+			  )`
+			)
+			.orderBy('a.mo_no', 'DESC')
+			.addOrderBy('a.created', 'DESC')
+			.setParameters({
+				search: params['q'],
+				factoryCode: params['factory_code.eq'],
+				color: params['mat_ecolor.eq']
+			})
+			.getRawMany()
 	}
 }

--- a/src/modules/rfid/services/rfid-outbound.service.ts
+++ b/src/modules/rfid/services/rfid-outbound.service.ts
@@ -118,41 +118,37 @@ export class RFIDOutboundService {
 			deleted: false,
 			scannable: true
 		}
+
 		/**
-		 * In case of multiple command numbers, we need to filter by mo_no and size_numcode
-		 * Otherwise, with single command number, we need to filter by mo_no, size_numcode and limit quantity
+		 * ? In case of multiple command numbers, filter by mo_no and size_numcode
+		 * ? Otherwise, with single command number, filter by mo_no, size_numcode and limit quantity
 		 */
-
 		const epcToUpsert = await (async () => {
-			if (Array.isArray(payload.sizes)) {
-				{
-					const facetPipeline = payload.sizes.reduce<PipelineStage.Facet['$facet']>((acc, curr) => {
-						return {
-							...acc,
-							[curr.size_numcode]: [
-								{ $match: { ...baseFilterQuery, mo_no: payload.mo_no, size_numcode: curr.size_numcode } },
-								{
-									$project: {
-										_id: 0,
-										epc: 1,
-										mo_no: 1,
-										size_numcode: 1,
-										station_no: 1,
-										factory_code_produce: 1
-									}
-								},
-								{ $limit: curr.qty }
-							]
-						}
-					}, {})
-					const aggregatedEpcData = await this.epcOutboundModel.aggregate([{ $facet: facetPipeline }])
-					const extractedValues = Object.values<Array<Partial<EpcDocument>>>(aggregatedEpcData[0])
-
-					return extractedValues.every((facetGroup) => Array.isArray(facetGroup)) ? extractedValues.flat() : []
-				}
+			if (!Array.isArray(payload.sizes)) {
+				return await this.epcOutboundModel.find({ ...baseFilterQuery, mo_no: payload.mo_no }).lean(true)
 			}
-
-			return await this.epcOutboundModel.find({ ...baseFilterQuery, mo_no: payload.mo_no }).lean(true)
+			const facetPipeline = payload.sizes.reduce<PipelineStage.Facet['$facet']>((acc, curr) => {
+				return {
+					...acc,
+					[curr.size_numcode]: [
+						{ $match: { ...baseFilterQuery, mo_no: payload.mo_no, size_numcode: curr.size_numcode } },
+						{
+							$project: {
+								_id: 0,
+								epc: 1,
+								mo_no: 1,
+								size_numcode: 1,
+								station_no: 1,
+								factory_code_produce: 1
+							}
+						},
+						{ $limit: curr.qty }
+					]
+				}
+			}, {})
+			const aggregatedEpcData = await this.epcOutboundModel.aggregate([{ $facet: facetPipeline }])
+			const extractedValues = Object.values<Array<Partial<EpcDocument>>>(aggregatedEpcData[0])
+			return extractedValues.every((facetGroup) => Array.isArray(facetGroup)) ? extractedValues.flat() : []
 		})()
 
 		const session = await this.epcOutboundModel.startSession()

--- a/src/modules/rfid/sql/upsert-stock-out.sql
+++ b/src/modules/rfid/sql/upsert-stock-out.sql
@@ -1,23 +1,59 @@
-MERGE INTO DV_DATA_LAKE.dbo.dv_InvRFIDrecorddet AS target
-USING (VALUES :values) AS source (EPC_Code, po, mo_no, size_code, stationNO, FC_server_code)
-ON 
-   target.EPC_Code = source.EPC_Code 
-   AND target.mo_no = source.mo_no
-   AND target.stationNO = source.stationNO
-WHEN MATCHED THEN
-   UPDATE SET 
-      created = CAST(GETDATE() AS DATETIME),
-      mo_no = source.mo_no, 
-      size_code = source.size_code,
-      record_time = CAST(GETDATE() AS DATETIME), 
-      stationNO = source.stationNO,
-      FC_server_code = source.FC_server_code,
-      quantity = -1,
-      po = source.po
-WHEN NOT MATCHED THEN
-   INSERT (
-      EPC_Code, po, mo_no, size_code, rfid_status, rfid_use, record_time, stationNO, FC_server_code, quantity
-   )
-   VALUES (
-      source.EPC_Code, source.po, source.mo_no, source.size_code, 'B', 'D', CAST(GETDATE() AS DATETIME), source.stationNO, source.FC_server_code, -1 
-   );
+BEGIN TRY
+   BEGIN TRANSACTION;
+
+   -- Upsert new outstock records
+   MERGE INTO DV_DATA_LAKE.dbo.dv_InvRFIDrecorddet AS target
+   USING (VALUES :values) AS source (EPC_Code, po, mo_no, size_code, stationNO, FC_server_code)
+   ON 
+      target.EPC_Code = source.EPC_Code 
+      AND target.mo_no = source.mo_no
+      AND target.stationNO = source.stationNO
+   WHEN MATCHED THEN
+      UPDATE SET 
+         created = CAST(GETDATE() AS DATETIME),
+         mo_no = source.mo_no, 
+         size_code = source.size_code,
+         record_time = CAST(GETDATE() AS DATETIME), 
+         stationNO = source.stationNO,
+         FC_server_code = source.FC_server_code,
+         quantity = -1,
+         po = source.po
+   WHEN NOT MATCHED THEN
+      INSERT (
+         EPC_Code, po, mo_no, size_code, rfid_status, rfid_use, record_time, stationNO, FC_server_code, quantity
+      )
+      VALUES (
+         source.EPC_Code, source.po, source.mo_no, source.size_code, 'B', 'D', CAST(GETDATE() AS DATETIME), source.stationNO, source.FC_server_code, -1 
+      );
+
+   -- Update existing instock records
+   MERGE INTO DV_DATA_LAKE.dbo.dv_InvRFIDrecorddet AS target
+   USING (VALUES :values) AS source (EPC_Code, po, mo_no, size_code, stationNO, FC_server_code)
+   ON 
+      target.EPC_Code = source.EPC_Code 
+      AND target.mo_no = source.mo_no
+      AND target.stationNO = 'A'
+   WHEN MATCHED THEN
+      UPDATE SET po = source.po;
+
+   MERGE INTO DV_DATA_LAKE.dbo.dv_InvRFIDrecorddet_backup_Daily AS target
+   USING (VALUES :values) AS source (EPC_Code, po, mo_no, size_code, stationNO, FC_server_code)
+   ON 
+      target.EPC_Code = source.EPC_Code 
+      AND target.mo_no = source.mo_no
+      AND target.stationNO = 'A'
+   WHEN MATCHED THEN
+      UPDATE SET po = source.po;
+
+   -- Commit the transaction if everything is successful
+   COMMIT TRANSACTION;
+END TRY
+BEGIN CATCH
+   -- Rollback the transaction in case of an error
+   ROLLBACK TRANSACTION;
+
+   -- Handle the error
+   PRINT 'Error occurred: ' + ERROR_MESSAGE();
+END CATCH;
+
+


### PR DESCRIPTION
This pull request introduces several updates across multiple services and SQL scripts to enhance query functionality, improve code clarity, and add transactional integrity to database operations. The most significant changes include adding conditional filtering logic in queries, refactoring code for better readability, and implementing transactional handling in SQL operations.

### Query Enhancements:
* **`OrderService` (`src/modules/order/order.service.ts`)**: Added conditional filtering logic based on `factoryCode` to refine query results. The filtering ensures that only relevant manufacturing orders are fetched based on the first three characters of `mo_no`. Parameters are now explicitly set using `.setParameters`.
* **`RFIDInboundService` (`src/modules/rfid/services/rfid-inbound.service.ts`)**: Migrated from raw SQL queries to a `QueryBuilder` approach, adding conditional filtering logic similar to `OrderService`. Enhanced query readability and maintainability by structuring the query and using `.setParameters` for dynamic values.

### Code Refactoring:
* **`RFIDOutboundService` (`src/modules/rfid/services/rfid-outbound.service.ts`)**: Refactored logic for handling `payload.sizes` to simplify the conditional structure. Removed redundant code and improved readability by reorganizing the `epcToUpsert` logic. [[1]](diffhunk://#diff-23374604e3f760ee84b381aba08148c6cf4a4bbf4ec0fcb616bcbcf9e7824f9dR121-R129) [[2]](diffhunk://#diff-23374604e3f760ee84b381aba08148c6cf4a4bbf4ec0fcb616bcbcf9e7824f9dL150-L155)

### SQL Transactional Handling:
* **`upsert-stock-out.sql` (`src/modules/rfid/sql/upsert-stock-out.sql`)**: Introduced transactional handling using `BEGIN TRY` and `BEGIN CATCH` blocks. Added logic to update existing records in both the main and backup tables when matches are found, ensuring data consistency. Transactions are committed on success and rolled back on failure, with error messages logged for debugging. [[1]](diffhunk://#diff-2ab5e1062f4e8b3f42621d3efbb566670049c9fb741415aff606295bc451f048R1-R4) [[2]](diffhunk://#diff-2ab5e1062f4e8b3f42621d3efbb566670049c9fb741415aff606295bc451f048R28-R59)