### PR TITLE
Fix/socket jwt

### DIFF
--- a/src/events/event.gateway.ts
+++ b/src/events/event.gateway.ts
@@ -17,6 +17,7 @@ import {
 	MessageBody,
 	OnGatewayConnection,
 	OnGatewayDisconnect,
+	OnGatewayInit,
 	SubscribeMessage,
 	WebSocketGateway,
 	WebSocketServer
@@ -36,7 +37,7 @@ const ACCESS_TOKEN_KEY = 'access-token'
 	},
 	httpCompression: true
 })
-export class EventGateway implements OnGatewayConnection, OnGatewayDisconnect {
+export class EventGateway implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect {
 	@WebSocketServer()
 	server: Server
 
@@ -59,6 +60,32 @@ export class EventGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		private readonly syncInventoryAuditDataQueue: Queue<SyncDataMessageDTO>
 	) {}
 
+	/**
+	 * @description Register a socket.io middleware that verifies the access token on every incoming event.
+	 * This ensures that expired/invalid tokens are caught even after the initial connection handshake.
+	 */
+	public afterInit(server: Server): void {
+		server.use(async (socket: Socket, next) => {
+			try {
+				const accessToken = this.extractTokenFromCookie(socket)
+				console.log('EventGateway token:>>>', accessToken)
+				if (!accessToken) {
+					return next(new Error('Missing access token'))
+				}
+				const user = await this.jwtService.verifyAsync<RequestUser>(accessToken)
+				socket.data.user = user
+				next()
+			} catch (error) {
+				const message = error instanceof JsonWebTokenError ? 'Invalid or expired token' : 'Authentication failed'
+				this.server.emit('auth_error', {})
+				this.logger.warn({ socketId: socket.id, error: (error as Error).message }, message)
+				next(new Error(message))
+			}
+		})
+
+		this.logger.info('WebSocket gateway initialized with auth middleware')
+	}
+
 	public async handleConnection(socket: Socket): Promise<void> {
 		const socketId = socket.id
 		const headers = socket.handshake.headers
@@ -77,7 +104,6 @@ export class EventGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
 			// Attach extra headers sent during reconnect attempts (factory code, username, etc.)
 			socket.data.factoryCode = headers[CommonRequestHeader.FACTORY_CODE.toLowerCase()] as string
-			socket.data.userRequest = headers[CommonRequestHeader.USER_REQUEST.toLowerCase()] as string
 
 			this.logger.info({ socketId, username: user.username }, 'Client connected')
 		} catch (error) {
@@ -122,7 +148,7 @@ export class EventGateway implements OnGatewayConnection, OnGatewayDisconnect {
 	@SubscribeMessage('sync_decker_data')
 	@UseFilters(new WsExceptionsFilter())
 	@UsePipes(new WsZodValidationPipe(syncDataMessageValidator))
-	protected async onSyncDeckerData(@MessageBody() payload: SyncDataMessageDTO) {
+	protected async handleSyncDeckersData(@MessageBody() payload: SyncDataMessageDTO) {
 		if (!this.syncThirdPartyApiDataQueue) return
 		const validUnknownEpcs = await this.epcModel
 			.distinct('epc', {
@@ -142,7 +168,7 @@ export class EventGateway implements OnGatewayConnection, OnGatewayDisconnect {
 	@SubscribeMessage('sync_inventory_audit_data')
 	@UseFilters(new WsExceptionsFilter())
 	@UsePipes(new WsZodValidationPipe(syncInventoryAuditValidator))
-	protected async onSyncInventoryAuditData(@MessageBody() payload: SyncInventoryAuditDTO) {
+	protected async handleSyncInventoryAuditData(@MessageBody() payload: SyncInventoryAuditDTO) {
 		if (!this.syncInventoryAuditDataQueue) return
 		this.syncInventoryAuditDataQueue.add(uniqueId(), {}, { jobId: payload.tenantId })
 	}

--- a/src/events/event.gateway.ts
+++ b/src/events/event.gateway.ts
@@ -63,27 +63,31 @@ export class EventGateway implements OnGatewayInit, OnGatewayConnection, OnGatew
 	/**
 	 * @description Register a socket.io middleware that verifies the access token on every incoming event.
 	 * This ensures that expired/invalid tokens are caught even after the initial connection handshake.
+	 *
+	 * * NOTE: `server.use()` runs during handshake (before connection) — socket.emit() won't reach the client.
+	 * * `socket.use()` runs AFTER connection, on every incoming event packet — socket.emit() works correctly.
 	 */
 	public afterInit(server: Server): void {
-		server.use(async (socket: Socket, next) => {
-			try {
-				const accessToken = this.extractTokenFromCookie(socket)
-				console.log('EventGateway token:>>>', accessToken)
-				if (!accessToken) {
-					return next(new Error('Missing access token'))
+		server.on('connection', (socket: Socket) => {
+			socket.use(async (_event, next) => {
+				try {
+					const user = await this.verifyAccessToken(socket)
+					socket.data.user = user
+					next()
+				} catch (error) {
+					if (error instanceof JsonWebTokenError) {
+						this.logger.warn({ socketId: socket.id, error: error.message }, 'Token expired/invalid on event')
+						socket.emit('jwt_expired', {
+							event: 'jwt_expired',
+							ok: false,
+							error: { name: error.name, message: error.message }
+						})
+						return
+					}
+					next(new Error('Authentication failed'))
 				}
-				const user = await this.jwtService.verifyAsync<RequestUser>(accessToken)
-				socket.data.user = user
-				next()
-			} catch (error) {
-				const message = error instanceof JsonWebTokenError ? 'Invalid or expired token' : 'Authentication failed'
-				this.server.emit('auth_error', {})
-				this.logger.warn({ socketId: socket.id, error: (error as Error).message }, message)
-				next(new Error(message))
-			}
+			})
 		})
-
-		this.logger.info('WebSocket gateway initialized with auth middleware')
 	}
 
 	public async handleConnection(socket: Socket): Promise<void> {
@@ -91,30 +95,22 @@ export class EventGateway implements OnGatewayInit, OnGatewayConnection, OnGatew
 		const headers = socket.handshake.headers
 
 		try {
-			const token = this.extractTokenFromCookie(socket)
-
-			if (!token) {
-				this.logger.warn({ socketId }, 'Client attempted connection without access token')
-				this.rejectConnection(socket, 'Missing access token')
-				return
-			}
-
-			const user = await this.jwtService.verifyAsync<RequestUser>(token)
+			const user = await this.verifyAccessToken(socket)
 			socket.data.user = user
 
 			// Attach extra headers sent during reconnect attempts (factory code, username, etc.)
 			socket.data.factoryCode = headers[CommonRequestHeader.FACTORY_CODE.toLowerCase()] as string
 
 			this.logger.info({ socketId, username: user.username }, 'Client connected')
-		} catch (error) {
-			const err = error instanceof JsonWebTokenError ? error : new Error(String(error))
-			const isJwtError = err.name === 'JsonWebTokenError' || err.name === 'TokenExpiredError'
+		} catch (e) {
+			const error = e instanceof JsonWebTokenError ? e : new Error(String(e))
+			const isJwtError = error.name === 'JsonWebTokenError' || error.name === 'TokenExpiredError'
 
 			this.logger.warn(
-				{ socketId, error: err.message },
+				{ socketId, error: error.message },
 				isJwtError ? 'Client connected with expired/invalid token' : 'Socket authentication failed'
 			)
-			this.rejectConnection(socket, isJwtError ? 'Invalid or expired token' : 'Authentication failed')
+			this.rejectConnection(socket, error)
 		}
 	}
 
@@ -138,10 +134,50 @@ export class EventGateway implements OnGatewayInit, OnGatewayConnection, OnGatew
 	}
 
 	/**
+	 * @description Extract the access token from the Authorization header (Bearer scheme).
+	 */
+	private extractTokenFromHeader(socket: Socket): string | undefined {
+		const authorization = socket.handshake.headers.authorization
+		if (!authorization) return undefined
+
+		const [scheme, token] = authorization.split(' ')
+		return scheme === 'Bearer' ? token : undefined
+	}
+
+	/**
+	 * @description Attempt to verify the access token from cookie first, then fallback to Authorization header.
+	 * @throws {JsonWebTokenError} If both sources fail verification.
+	 */
+	private async verifyAccessToken(socket: Socket): Promise<RequestUser> {
+		const cookieToken = this.extractTokenFromCookie(socket)
+		if (cookieToken) {
+			try {
+				return await this.jwtService.verifyAsync<RequestUser>(cookieToken)
+			} catch {
+				this.logger.debug({ socketId: socket.id }, 'Cookie token verification failed, trying Authorization header')
+			}
+		}
+
+		const headerToken = this.extractTokenFromHeader(socket)
+		if (!headerToken) {
+			throw new JsonWebTokenError('No valid access token found in cookie or Authorization header')
+		}
+
+		return await this.jwtService.verifyAsync<RequestUser>(headerToken)
+	}
+
+	/**
 	 * @description Reject a socket connection by emitting an auth error and disconnecting.
 	 */
-	private rejectConnection(socket: Socket, reason: string): void {
-		socket.emit('auth_error', { message: reason })
+	private rejectConnection(socket: Socket, error: Error | JsonWebTokenError): void {
+		const isTokenExpired = error instanceof JsonWebTokenError
+		const event = isTokenExpired ? 'jwt_expired' : 'auth_error'
+		socket.emit(event, {
+			event,
+			ok: false,
+			message: isTokenExpired ? 'Access token has expired. Please refresh your token and reconnect.' : error.message,
+			metadata: null
+		})
 		socket.disconnect(true)
 	}
 


### PR DESCRIPTION
This pull request enhances the authentication flow for the WebSocket gateway by introducing middleware to verify access tokens on every incoming event, improving error handling, and supporting token extraction from both cookies and headers. The changes also refactor method names for clarity and update interface implementations.

Authentication improvements:

* Added `OnGatewayInit` implementation and introduced the `afterInit` method to register a socket middleware that verifies access tokens on every incoming event, ensuring expired or invalid tokens are caught after connection. [[1]](diffhunk://#diff-187588d4ffe9549f40040f96bb1a4ec39f3352362fa7e51c9393a4c3d1f53589R20) [[2]](diffhunk://#diff-187588d4ffe9549f40040f96bb1a4ec39f3352362fa7e51c9393a4c3d1f53589L39-R40) [[3]](diffhunk://#diff-187588d4ffe9549f40040f96bb1a4ec39f3352362fa7e51c9393a4c3d1f53589R63-R113)
* Added methods to extract access tokens from the Authorization header and verify tokens from both cookies and headers, with fallback logic and improved error handling.

Error handling enhancements:

* Updated the `rejectConnection` method to emit specific events (`jwt_expired` or `auth_error`) based on the error type, providing clearer feedback to clients.

Code refactoring:

* Renamed handler methods for `sync_decker_data` and `sync_inventory_audit_data` events to `handleSyncDeckersData` and `handleSyncInventoryAuditData` for improved clarity and consistency. [[1]](diffhunk://#diff-187588d4ffe9549f40040f96bb1a4ec39f3352362fa7e51c9393a4c3d1f53589R136-R187) [[2]](diffhunk://#diff-187588d4ffe9549f40040f96bb1a4ec39f3352362fa7e51c9393a4c3d1f53589L145-R207)