### PR TITLE
Feat/rfid watchers

### DIFF
--- a/src/modules/rfid/controllers/rfid-inbound.controller.ts
+++ b/src/modules/rfid/controllers/rfid-inbound.controller.ts
@@ -4,6 +4,7 @@ import { AllExceptionsFilter } from '@/common/filters'
 import { ZodValidationPipe } from '@/common/pipes'
 import { UserRole } from '@/modules/user/constants'
 import { InjectQueue } from '@nestjs/bullmq'
+import { CACHE_MANAGER } from '@nestjs/cache-manager'
 import {
 	Body,
 	Controller,
@@ -11,6 +12,7 @@ import {
 	Get,
 	Headers,
 	HttpStatus,
+	Inject,
 	Param,
 	ParseBoolPipe,
 	ParseIntPipe,
@@ -21,6 +23,7 @@ import {
 import { EventEmitter2 } from '@nestjs/event-emitter'
 import { InjectModel } from '@nestjs/mongoose'
 import { Queue } from 'bullmq'
+import { Cache } from 'cache-manager'
 import { format } from 'date-fns'
 import { FastifyReply } from 'fastify'
 import { isEmpty, isNil, pick, pickBy } from 'lodash'
@@ -52,10 +55,13 @@ import { RFIDSearchParams, ScannedOrderDetail } from '../types'
 
 @Controller('rfid/inbound')
 export class RFIDInboundController {
+	private inboundWatcher: number = 0
+
 	constructor(
 		@InjectPinoLogger(RFIDInboundController.name) private readonly logger: PinoLogger,
 		@InjectModel(EpcInbound.name) private readonly epcInboundModel: EpcModel,
 		@InjectQueue(POST_DATA_INBOUND_QUEUE) private readonly postInboundDataQueue: Queue<PostReaderDataDTO>,
+		@Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
 		private readonly eventEmitter: EventEmitter2,
 		private readonly rfidSharedService: RFIDSharedService,
 		private readonly rfidInboundService: RFIDInboundService
@@ -82,14 +88,22 @@ export class RFIDInboundController {
 			})
 			if (data) reply.sse(data)
 		}
+
 		await handleChange()
+		let currentWatchers = await this.cacheManager.get<number>('cached:rfid:inbound_watchers')
+		await this.cacheManager.set('cached:rfid:inbound_watchers', currentWatchers ? currentWatchers + 1 : 1)
 		const changeStream = await this.rfidSharedService.captureDataChange(this.epcInboundModel, handleChange)
 
 		reply.raw.on('close', async () => {
-			this.logger.info('Stop receiving data from Android RFID device')
-			await this.rfidSharedService.cleanupQueue(this.postInboundDataQueue)
-			changeStream.removeListener('change', handleChange)
-			changeStream.close()
+			currentWatchers = await this.cacheManager.get<number>('cached:rfid:inbound_watchers')
+			await this.cacheManager.set('cached:rfid:inbound_watchers', currentWatchers - 1)
+			currentWatchers = await this.cacheManager.get<number>('cached:rfid:inbound_watchers')
+			if (currentWatchers === 0) {
+				this.logger.info('Stop receiving data from Android RFID device')
+				await this.rfidSharedService.cleanupQueue(this.postInboundDataQueue)
+				changeStream.removeListener('change', handleChange)
+				changeStream.close()
+			}
 			reply.raw.end()
 		})
 	}

--- a/src/modules/rfid/controllers/rfid-inbound.controller.ts
+++ b/src/modules/rfid/controllers/rfid-inbound.controller.ts
@@ -3,6 +3,7 @@ import { HttpMethod, Public, RequestUser, RequireAuthorized, RouteHandler, User 
 import { AllExceptionsFilter } from '@/common/filters'
 import { ZodValidationPipe } from '@/common/pipes'
 import { UserRole } from '@/modules/user/constants'
+import { RedisService } from '@/redis/redis.service'
 import { InjectQueue } from '@nestjs/bullmq'
 import { CACHE_MANAGER } from '@nestjs/cache-manager'
 import {
@@ -29,6 +30,7 @@ import { FastifyReply } from 'fastify'
 import { isEmpty, isNil, pick, pickBy } from 'lodash'
 import { PaginateResult } from 'mongoose'
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino'
+import z from 'zod'
 import { POST_DATA_INBOUND_QUEUE } from '../constants'
 import {
 	ExchangeOrderDTO,
@@ -55,13 +57,12 @@ import { RFIDSearchParams, ScannedOrderDetail } from '../types'
 
 @Controller('rfid/inbound')
 export class RFIDInboundController {
-	private inboundWatcher: number = 0
-
 	constructor(
 		@InjectPinoLogger(RFIDInboundController.name) private readonly logger: PinoLogger,
 		@InjectModel(EpcInbound.name) private readonly epcInboundModel: EpcModel,
 		@InjectQueue(POST_DATA_INBOUND_QUEUE) private readonly postInboundDataQueue: Queue<PostReaderDataDTO>,
 		@Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
+		private readonly redisService: RedisService,
 		private readonly eventEmitter: EventEmitter2,
 		private readonly rfidSharedService: RFIDSharedService,
 		private readonly rfidInboundService: RFIDInboundService
@@ -106,6 +107,27 @@ export class RFIDInboundController {
 			}
 			reply.raw.end()
 		})
+	}
+
+	@Get('enable_deduplicate_inbound_epc')
+	@RequireAuthorized(UserRole.MANAGER, UserRole.FG_WAREHOUSE_STAFF)
+	@UseFilters(AllExceptionsFilter)
+	async getIsDeduplicationEnabled(@Res() reply: FastifyReply & { sse: (data: { enabled: boolean }) => void }) {
+		const isDeduplicationEnabled = await this.cacheManager.get<boolean>('cached:rfid:enable_deduplicate_inbound_epc')
+		reply.sse({ enabled: isDeduplicationEnabled })
+		this.redisService.subscribe('enable_deduplicate_inbound_epc', (message) => {
+			reply.sse({ enabled: JSON.parse(message) })
+		})
+	}
+
+	@RouteHandler({ endpoint: 'enable_deduplicate_inbound_epc', method: HttpMethod.PUT })
+	@RequireAuthorized(UserRole.MANAGER, UserRole.FG_WAREHOUSE_STAFF)
+	@UseFilters(AllExceptionsFilter)
+	async enableDeduplication(
+		@Body(new ZodValidationPipe(z.object({ enabled: z.boolean() }))) payload: { enabled: boolean }
+	) {
+		await this.cacheManager.set<boolean>('cached:rfid:enable_deduplicate_inbound_epc', payload.enabled)
+		return await this.redisService.publish('enable_deduplicate_inbound_epc', JSON.stringify(payload.enabled))
 	}
 
 	@RouteHandler({
@@ -231,7 +253,6 @@ export class RFIDInboundController {
 			deviceSeriesNumber: payload.sn,
 			lastUsageTime: format(new Date(), 'yyyy-MM-dd HH:mm:ss.SSS')
 		})
-
 		return await this.rfidInboundService.postInboundRFIDData(payload)
 	}
 

--- a/src/modules/rfid/controllers/rfid-outbound.controller.ts
+++ b/src/modules/rfid/controllers/rfid-outbound.controller.ts
@@ -9,6 +9,7 @@ import {
 	DefaultValuePipe,
 	Get,
 	HttpStatus,
+	Inject,
 	Param,
 	ParseBoolPipe,
 	ParseIntPipe,
@@ -27,6 +28,9 @@ import { PaginateResult } from 'mongoose'
 import { POST_DATA_OUTBOUND_QUEUE } from '../constants'
 
 import { UserRole } from '@/modules/user/constants'
+import { CACHE_MANAGER } from '@nestjs/cache-manager'
+import { Cache } from 'cache-manager'
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino'
 import { UpsertStockOutDTO, upsertStockOutValidator } from '../dto/rfid-outbound.dto'
 import {
 	deleteEpcValidator,
@@ -46,6 +50,8 @@ export class RFIDOutboundController {
 	constructor(
 		@InjectQueue(POST_DATA_OUTBOUND_QUEUE) private readonly postOutboundDataQueue: Queue<PostReaderDataDTO>,
 		@InjectModel(EpcOutbound.name) private readonly epcOutboundModel: EpcModel,
+		@Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
+		@InjectPinoLogger(RFIDOutboundController.name) private readonly logger: PinoLogger,
 		private readonly eventEmitter: EventEmitter2,
 		private readonly rfidSharedService: RFIDSharedService,
 		private readonly rfidOutboundService: RFIDOutboundService
@@ -74,9 +80,19 @@ export class RFIDOutboundController {
 		}
 		await handleChange()
 		const changeStream = this.rfidSharedService.captureDataChange(this.epcOutboundModel, handleChange)
+		let currentWatchers = await this.cacheManager.get<number>('cached:rfid:outbound_watchers')
+		await this.cacheManager.set('cached:rfid:outbound_watchers', currentWatchers ? currentWatchers + 1 : 1)
+
 		reply.raw.on('close', async () => {
-			changeStream.removeListener('change', handleChange)
-			await changeStream.close()
+			currentWatchers = await this.cacheManager.get<number>('cached:rfid:outbound_watchers')
+			await this.cacheManager.set('cached:rfid:outbound_watchers', currentWatchers - 1)
+			currentWatchers = await this.cacheManager.get<number>('cached:rfid:outbound_watchers')
+			if (currentWatchers === 0) {
+				this.logger.info('Stop receiving data from Android RFID device')
+				await this.rfidSharedService.cleanupQueue(this.postOutboundDataQueue)
+				changeStream.removeListener('change', handleChange)
+				await changeStream.close()
+			}
 			reply.raw.end()
 		})
 	}

--- a/src/modules/rfid/rfid.module.ts
+++ b/src/modules/rfid/rfid.module.ts
@@ -1,9 +1,11 @@
 import { DATA_SOURCE_DATA_LAKE } from '@/databases/constants'
 import { EventGateway } from '@/events/event.gateway'
 import { BullModule } from '@nestjs/bullmq'
-import { Module, OnModuleInit } from '@nestjs/common'
+import { CACHE_MANAGER } from '@nestjs/cache-manager'
+import { Inject, Module, OnModuleInit } from '@nestjs/common'
 import { InjectModel, MongooseModule } from '@nestjs/mongoose'
 import { TypeOrmModule } from '@nestjs/typeorm'
+import { Cache } from 'cache-manager'
 import MongooseDeletePlugin from 'mongoose-delete'
 import MongoosePaginatePlugin from 'mongoose-paginate-v2'
 import { PinoLogger } from 'nestjs-pino'
@@ -99,6 +101,7 @@ import { RFIDCustomerEntitySubscriber } from './subscribers/rfid-customer.entity
 export class RFIDModule implements OnModuleInit {
 	constructor(
 		private readonly logger: PinoLogger,
+		@Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
 		@InjectModel(EpcInbound.name) private readonly epcInboundModel: EpcModel,
 		@InjectModel(EpcOutbound.name) private readonly epcOutboundModel: EpcModel
 	) {}
@@ -106,6 +109,10 @@ export class RFIDModule implements OnModuleInit {
 	async onModuleInit() {
 		try {
 			await Promise.all([this.epcInboundModel.syncIndexes(), this.epcOutboundModel.syncIndexes()])
+			await Promise.all([
+				this.cacheManager.set('cached:rfid:inbound_watchers', 0),
+				this.cacheManager.set('cached:rfid:outbound_watchers', 0)
+			])
 		} catch (error) {
 			this.logger.error(error)
 		}

--- a/src/modules/rfid/rfid.module.ts
+++ b/src/modules/rfid/rfid.module.ts
@@ -111,7 +111,8 @@ export class RFIDModule implements OnModuleInit {
 			await Promise.all([this.epcInboundModel.syncIndexes(), this.epcOutboundModel.syncIndexes()])
 			await Promise.all([
 				this.cacheManager.set('cached:rfid:inbound_watchers', 0),
-				this.cacheManager.set('cached:rfid:outbound_watchers', 0)
+				this.cacheManager.set('cached:rfid:outbound_watchers', 0),
+				this.cacheManager.set('cached:rfid:enable_deduplicate_inbound_epc', true)
 			])
 		} catch (error) {
 			this.logger.error(error)

--- a/src/modules/rfid/services/rfid-inbound.service.ts
+++ b/src/modules/rfid/services/rfid-inbound.service.ts
@@ -4,11 +4,20 @@ import { EventGateway } from '@/events/event.gateway'
 import { IUpsertInventoryEventPayload } from '@/modules/inventory/interfaces'
 import { InventoryAuditService } from '@/modules/inventory/services/inventory-audit.service'
 import { InjectQueue } from '@nestjs/bullmq'
-import { BadRequestException, Injectable, InternalServerErrorException, NotFoundException, Scope } from '@nestjs/common'
+import { CACHE_MANAGER } from '@nestjs/cache-manager'
+import {
+	BadRequestException,
+	Inject,
+	Injectable,
+	InternalServerErrorException,
+	NotFoundException,
+	Scope
+} from '@nestjs/common'
 import { EventEmitter2, OnEvent } from '@nestjs/event-emitter'
 import { InjectModel } from '@nestjs/mongoose'
 import { InjectDataSource } from '@nestjs/typeorm'
 import { Queue } from 'bullmq'
+import { Cache } from 'cache-manager'
 import { format } from 'date-fns'
 import { chunk, pick } from 'lodash'
 import { AnyBulkWriteOperation, FilterQuery } from 'mongoose'
@@ -38,6 +47,7 @@ export class RFIDInboundService {
 		@InjectDataSource(DATA_SOURCE_ERP) private readonly dataSourceERP: DataSource,
 		@InjectQueue(POST_DATA_INBOUND_QUEUE) private readonly postDataQueue: Queue<PostReaderDataDTO>,
 		@InjectModel(EpcInbound.name) private readonly epcInboundModel: EpcModel,
+		@Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
 		private readonly i18nService: I18nService,
 		private readonly inventoryAuditService: InventoryAuditService,
 		private readonly eventEmitter: EventEmitter2,
@@ -46,10 +56,12 @@ export class RFIDInboundService {
 	) {}
 
 	public async postInboundRFIDData(data: PostReaderDataDTO) {
-		await this.eventEmitter.emitAsync(
-			'rfid.inbound.check',
-			data.data.tagList.map((item) => item.epc)
-		)
+		const isDeduplicationEnabled = await this.cacheManager.get<boolean>('cached:rfid:enable_deduplicate_inbound_epc')
+		if (!isDeduplicationEnabled)
+			await this.eventEmitter.emitAsync(
+				'rfid.inbound.check',
+				data.data.tagList.map((item) => item.epc)
+			)
 		return await this.postDataQueue.add('RFID_INBOUND', data, { lifo: true })
 	}
 

--- a/src/modules/rfid/services/rfid-shared.service.ts
+++ b/src/modules/rfid/services/rfid-shared.service.ts
@@ -1,16 +1,17 @@
 import { VALID_EPC_PATTERN } from '@/common/constants/regex'
 import { DATA_SOURCE_DATA_LAKE } from '@/databases/constants'
-import { Injectable } from '@nestjs/common'
+import { CACHE_MANAGER } from '@nestjs/cache-manager'
+import { Inject, Injectable } from '@nestjs/common'
 import { InjectModel } from '@nestjs/mongoose'
 import { InjectDataSource } from '@nestjs/typeorm'
 import { Queue } from 'bullmq'
+import { Cache } from 'cache-manager'
 import { throttle } from 'lodash'
 import { AnyBulkWriteOperation, FilterQuery, mongo, UpdateWriteOpResult } from 'mongoose'
 import { readFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import { DataSource } from 'typeorm'
 import { EXCLUDED_EPC_PREFIX, EXCLUDED_ORDERS, FALLBACK_VALUE } from '../constants'
-
 import { FindEpcBySizeDTO, PostReaderDataDTO, RestoreArchivedEpcsDTO } from '../dto/rfid-shared.dto'
 import { EpcDocument, EpcInbound, EpcModel, EpcOutbound, EpcSchema } from '../schemas/epc.schema'
 import { RFIDSearchParams, ScannedOrderDetail, StoredRFIDReaderItem } from '../types'
@@ -22,8 +23,13 @@ export class RFIDSharedService {
 		resolve(join(__dirname, '../sql/epc-information.sql')),
 		'utf-8'
 	)
+	private readonly deduplicatedEpcInformationQuery: string = readFileSync(
+		resolve(join(__dirname, '../sql/deduplicated-epc-information.sql')),
+		'utf-8'
+	)
 
 	constructor(
+		@Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
 		@InjectDataSource(DATA_SOURCE_DATA_LAKE) private readonly dataSourceDL: DataSource,
 		@InjectModel(EpcInbound.name) private readonly epcInboundModel: EpcModel,
 		@InjectModel(EpcOutbound.name) private readonly epcOutboundModel: EpcModel,
@@ -203,7 +209,11 @@ export class RFIDSharedService {
 		 * * Get the EPCs information from the database with received data
 		 * * Do not receive EPCs that start with '303429' (Dansko's EPCs)
 		 */
-		const scannedEpcs = await this.dataSourceDL.query<StoredRFIDReaderItem[]>(this.epcInformationQuery, [
+		const isDeduplicationEnabled = await this.cacheManager.get<boolean>('cached:rfid:enable_deduplicate_inbound_epc')
+
+		const epcInfoQuery = isDeduplicationEnabled ? this.deduplicatedEpcInformationQuery : this.epcInformationQuery
+
+		const scannedEpcs = await this.dataSourceDL.query<StoredRFIDReaderItem[]>(epcInfoQuery, [
 			epcList,
 			excludedOrderList
 		])

--- a/src/modules/rfid/sql/deduplicated-epc-information.sql
+++ b/src/modules/rfid/sql/deduplicated-epc-information.sql
@@ -1,0 +1,26 @@
+DECLARE @FallbackValue NVARCHAR(10) = 'Unknown';
+
+WITH inbound_epcs AS (
+   SELECT EPC_Code FROM DV_DATA_LAKE.dbo.dv_InvRFIDrecorddet
+   UNION ALL
+   SELECT EPC_Code FROM DV_DATA_LAKE.dbo.dv_InvRFIDrecorddet_backup_Daily
+)
+SELECT DISTINCT a.EPC_Code AS epc, 
+   ISNULL(b.mo_no, @FallbackValue) AS mo_no,
+   COALESCE(b.shoestyle_codefactory, @FallbackValue) AS factory_shoes_style,
+   COALESCE(c.color_sn, @FallbackValue) AS color_sn,
+   COALESCE(b.size_numcode, @FallbackValue) AS size_numcode,
+   b.factory_code_produce
+FROM (SELECT value AS EPC_Code FROM STRING_SPLIT(CAST(@0 AS NVARCHAR(MAX)), ',')) AS a
+LEFT JOIN DV_DATA_LAKE.dbo.dv_rfidmatchmst_cust b ON a.EPC_Code = b.EPC_Code
+LEFT JOIN wuerp_vnrd.dbo.ta_productmst c ON b.mat_code = c.mat_code
+WHERE 
+   a.EPC_Code NOT LIKE '303429%'
+   AND LEN(a.EPC_Code) = 24
+   AND (
+      b.mo_no IS NULL 
+      OR b.mo_no NOT IN (SELECT value AS mo_no FROM STRING_SPLIT(@1, ','))
+   )
+   AND a.EPC_Code NOT IN (
+      SELECT DISTINCT EPC_Code FROM inbound_epcs
+   )


### PR DESCRIPTION
This pull request introduces a system-wide mechanism to enable or disable deduplication of inbound RFID EPCs via a cache-backed flag, with support for real-time updates and watcher tracking. It also adds initial values for these cache keys during module initialization, and conditionally queries deduplicated EPC information based on the flag. The changes span controllers, services, and SQL logic, providing both API endpoints and backend logic for deduplication control.

**Deduplication Control and Watcher Tracking:**

* Added endpoints in `rfid-inbound.controller.ts` to get and set the deduplication flag (`enable_deduplicate_inbound_epc`) using cache and Redis pub/sub for real-time updates.
* Updated both inbound and outbound controllers to track and manage the number of SSE watchers using cache, and to clean up resources when no watchers remain. [[1]](diffhunk://#diff-221cf30eadbaf5a2c55a9a36c2ea21838e4bc8cbf6d2b297adfc0fc4abe12339R92-R132) [[2]](diffhunk://#diff-461ea3ea98465357762190cd0d2e6547bbc259ad315f6d2bb0bc8f45a10be89fR83-R95)

**Cache Integration and Initialization:**

* Injected `CACHE_MANAGER` and initialized cache values (`inbound_watchers`, `outbound_watchers`, `enable_deduplicate_inbound_epc`) in `rfid.module.ts` during module startup.

**Deduplication Logic in Services:**

* Modified `RFIDInboundService` to check the deduplication flag before emitting deduplication events.
* Updated `RFIDSharedService` to select between standard and deduplicated EPC information queries based on the deduplication flag.

**SQL for Deduplicated EPC Information:**

* Added a new SQL script `deduplicated-epc-information.sql` to fetch deduplicated EPC info, excluding already-inbound EPCs and applying business rules.